### PR TITLE
remove unused packages, move testing related pkgs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,5 +215,4 @@ Dependencies
 - pprintpp: https://pypi.python.org/pypi/pprintpp
 - python-json-logger: https://pypi.python.org/pypi/python-json-logger
 - Pygments: https://pypi.python.org/pypi/Pygments
-- safe-cast: https://pypi.python.org/pypi/safe-cast
 - wheel: https://pypi.python.org/pypi/wheel

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -3,3 +3,9 @@ pep8
 pyflakes
 sphinx_rtd_theme
 yapf
+httpbin>=0.6.2
+pytest>=3.5.1
+pytest-cov>=2.5.1
+pytest-httpbin>=0.3.0
+pytest-mock>=1.10.0
+wheel>=0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,6 @@
 coloredlogs>=7.3
-httpbin>=0.6.2
 python-json-logger>=0.1.8
 pprintpp>=0.3.0
 Pygments>=2.2.0
-pytest>=3.5.1
-pytest-cov>=2.5.1
-pytest-httpbin>=0.3.0
-pytest-mock>=1.10.0
 pytz>=2018.4
-safe-cast>=0.1.1
 tzlocal>=1.5.1
-wheel>=0.30.0


### PR DESCRIPTION
In effort to make this package compatible with alpine docker image would be great to make it slimmer.
**safe-cast** which uses "healthy" numpy package isn't used at all in pyfortified-logging.
other testing related packages can be moved to requirements-tools.txt